### PR TITLE
Update the cwls.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # las-go is a GoLang library/package for parsing .Las file (Geophysical well log files).
 
-### Currently supports only version 2.0 of LAS Specification. For more information about this format, see the Canadian Well Logging Society [web page](http://www.cwls.org/las/)
+### Currently supports only version 2.0 of [LAS Specification](https://www.cwls.org/wp-content/uploads/2017/02/Las2_Update_Feb2017.pdf).  For more information about this format, see the Canadian Well Logging Society [product page](https://www.cwls.org/products/).
 
 ## How to use
 


### PR DESCRIPTION
The previous link reports: 'Not Found on the cwls.org site.

This pull request has these changes:

- Update the links to cwls.org to use https instead of http.
- Add link directly to the version 2.0 specification.
- Update the previous 'las' link to point to the 'product' page where the LAS specifications and tool information are located.


Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC