### PR TITLE
go.mod broken

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iykekings/las-go
+module github.com/laslibs/las-go
 
 go 1.13
 


### PR DESCRIPTION
Nice work!

It looks like there are some issues with go mod.

After running: 

```
go get github.com/laslibs/las-go
```

I get the following error:

```
go get: github.com/laslibs/las-go@v0.5.2: parsing go.mod:
        module declares its path as: github.com/iykekings/las-go
                but was required as: github.com/laslibs/las-go
```

and this is what my import looks like:

```golang
import (
    lasgo "github.com/iykekings/las-go"
)
```