### PR TITLE
fix go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
   ```go
   import (
-    lasgo "github.com/iykekings/las-go"
+    lasgo "github.com/laslibs/las-go"
   )
   ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iykekings/las-go
+module github.com/laslibs/las-go
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
-	lasgo "github.com/iykekings/las-go"
+	lasgo "github.com/laslibs/las-go"
 )
 
 func TestRowCount(t *testing.T) {


### PR DESCRIPTION
Running `go get github.com/laslibs/las-go` is broken..

Error:

```
$ go get github.com/laslibs/las-go
go: github.com/laslibs/las-go upgrade => v0.5.2
go get: github.com/laslibs/las-go@v0.5.2: parsing go.mod:
        module declares its path as: github.com/iykekings/las-go
                but was required as: github.com/laslibs/las-go
```